### PR TITLE
fix error if no host name associated with addr

### DIFF
--- a/src/telnetlib_proxy/__init__.py
+++ b/src/telnetlib_proxy/__init__.py
@@ -1,13 +1,12 @@
-
-import os
-import sys
-import socks
-import socket
-import termios
 import argparse
+import os
+import socket
+import sys
 import telnetlib
 from urllib.parse import urlparse
 
+import socks
+import termios
 
 __all__ = ["Telnet"]
 
@@ -40,6 +39,10 @@ def wait_key(echo=False):
 class Telnet(telnetlib.Telnet):
 
     def __init__(self, *args, **kwargs):
+        telnet_proxy = kwargs.pop('telnet_proxy', os.environ.get('telnet_proxy'))
+        if not telnet_proxy:
+            telnet_proxy = os.environ.get('telnet_proxy')
+        self.telnet_proxy = telnet_proxy
         super().__init__(*args, **kwargs)
         self.echo = False
 
@@ -67,7 +70,7 @@ class Telnet(telnetlib.Telnet):
         self.timeout = timeout
         sys.audit("telnetlib.Telnet.open", self, host, port)
 
-        proxy_url = kwargs.pop('telnet_proxy', os.environ.get('telnet_proxy'))
+        proxy_url = self.telnet_proxy
 
         if proxy_url:
             url_info = urlparse(proxy_url)

--- a/src/telnetlib_proxy/__init__.py
+++ b/src/telnetlib_proxy/__init__.py
@@ -89,8 +89,11 @@ class Telnet(telnetlib.Telnet):
 
         if proxy_args.get('proxy_addr'):
             self.sock = socks.create_connection((host, port), timeout, **proxy_args)
-            socks_hostname = socket.gethostbyaddr(proxy_args.get('proxy_addr'))[0]
-            print('Connected to {} via {}.'.format(target_hostname, socks_hostname))
+            try:
+                socks_hostname = socket.gethostbyaddr(proxy_args.get('proxy_addr'))[0]
+                print('Connected to {} via {}.'.format(target_hostname, socks_hostname))
+            except socket.herror as e:
+                print('Connected to {} via {}.'.format(target_hostname, proxy_args.get('proxy_addr')))
         else:
             self.sock = socket.create_connection((host, port), timeout)
             print('Connected to {}.'.format(target_hostname))

--- a/src/telnetlib_proxy/__init__.py
+++ b/src/telnetlib_proxy/__init__.py
@@ -67,7 +67,7 @@ class Telnet(telnetlib.Telnet):
         self.timeout = timeout
         sys.audit("telnetlib.Telnet.open", self, host, port)
 
-        proxy_url = os.environ.get('telnet_proxy')
+        proxy_url = kwargs.pop('telnet_proxy', os.environ.get('telnet_proxy'))
 
         if proxy_url:
             url_info = urlparse(proxy_url)


### PR DESCRIPTION
if no host is associated with ip address, original part of code raises herror

Original code doesn't contain useful actions, but drop in error if no host associated.

In this pull request we don't change original behavior that print associated host, but wrap it  to avoid exception.